### PR TITLE
Add bidirectional copy actions to env var compare UI

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,265 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  background-color: #1e1e1e;
+  color: #d4d4d4;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background-color: #252526;
+}
+
+.page-header {
+  background: linear-gradient(135deg, #0078d4 0%, #005a9e 100%);
+  color: #fff;
+  padding: 1.5rem 2rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.page-header p {
+  margin: 0.5rem 0 0;
+  max-width: 60ch;
+}
+
+.page-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem 2rem 2rem;
+}
+
+.editor-panel {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.panel {
+  border: 1px solid #3f3f46;
+  border-radius: 8px;
+  background-color: #1e1e1e;
+  display: flex;
+  flex-direction: column;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+}
+
+.panel__header {
+  background-color: #2d2d30;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  padding: 0.75rem 1rem;
+}
+
+.panel__header h2 {
+  margin: 0;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #9cdcfe;
+}
+
+.panel__editor {
+  flex: 1;
+  min-height: 240px;
+  resize: vertical;
+  border: none;
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+  padding: 1rem;
+  font-family: "Cascadia Code", "Fira Code", "Consolas", "Courier New", monospace;
+  font-size: 0.95rem;
+  background-color: #1b1b1f;
+  color: #d4d4d4;
+}
+
+.panel__editor:focus {
+  outline: none;
+  box-shadow: inset 0 0 0 2px #0078d4;
+}
+
+.helper-text {
+  margin: -0.5rem 0 0;
+  font-size: 0.9rem;
+  color: #9cdcfe;
+}
+
+.actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.btn {
+  background: linear-gradient(135deg, #0e639c 0%, #007acc 100%);
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 6px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+}
+
+.btn:active {
+  transform: none;
+  box-shadow: none;
+}
+
+.btn--secondary {
+  background: linear-gradient(135deg, #3c3c43 0%, #2d2d30 100%);
+}
+
+.status {
+  min-height: 1.5rem;
+  font-size: 0.95rem;
+  color: #d4d4d4;
+}
+
+.status.error {
+  color: #f44747;
+}
+
+.table-container {
+  border: 1px solid #3f3f46;
+  border-radius: 8px;
+  background-color: #1e1e1e;
+  overflow-x: auto;
+}
+
+.results {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.results th,
+.results td {
+  padding: 0.65rem 0.75rem;
+  border-bottom: 1px solid #3f3f46;
+  text-align: left;
+  vertical-align: top;
+}
+
+.results th {
+  background-color: #2d2d30;
+  color: #9cdcfe;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.85rem;
+}
+
+.results tbody tr:nth-child(even) td {
+  background-color: #1b1b1f;
+}
+
+.results tbody tr.match td {
+  color: #57a64a;
+}
+
+.results tbody tr.different td {
+  color: #f44747;
+}
+
+.results tbody tr.only-source td,
+.results tbody tr.only-target td {
+  color: #f9f1a5;
+}
+
+.results__actions-header {
+  width: 180px;
+}
+
+.results__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.action-button {
+  background: #343438;
+  color: #f3f3f3;
+  border: 1px solid #3f3f46;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  padding: 0.35rem 0.6rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.action-button:hover {
+  background: #3f3f46;
+}
+
+.action-button:focus {
+  outline: 2px solid #0078d4;
+  outline-offset: 2px;
+}
+
+.missing-value {
+  color: #808080 !important;
+  font-style: italic;
+}
+
+.page-footer {
+  padding: 1rem 2rem;
+  background-color: #1e1e1e;
+  border-top: 1px solid #3f3f46;
+  font-size: 0.85rem;
+  color: #969696;
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.legend__item {
+  padding: 0.4rem 0.65rem;
+  border-radius: 20px;
+  background-color: #333337;
+}
+
+.legend__item--match {
+  color: #57a64a;
+}
+
+.legend__item--different {
+  color: #f44747;
+}
+
+.legend__item--only-source,
+.legend__item--only-target {
+  color: #f9f1a5;
+}
+
+@media (max-width: 768px) {
+  .page-header,
+  .page-main,
+  .page-footer {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,480 @@
+const leftInput = document.getElementById("left-json");
+const rightInput = document.getElementById("right-json");
+const compareButton = document.getElementById("compare");
+const clearButton = document.getElementById("clear");
+const statusEl = document.getElementById("status");
+const resultTable = document.getElementById("result-table");
+const tbody = resultTable.querySelector("tbody");
+
+const MISSING_INDICATOR = "—";
+
+const toDisplayString = (value) => {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch (error) {
+      console.warn("Unable to stringify value", value, error);
+      return String(value);
+    }
+  }
+
+  return String(value ?? "");
+};
+
+const detectFormat = (parsed) => {
+  if (Array.isArray(parsed)) {
+    if (parsed.length === 0) {
+      return "nameValueArray";
+    }
+
+    const nameValueEntries = parsed.filter(
+      (item) => item && typeof item === "object" && !Array.isArray(item) && "name" in item && "value" in item
+    );
+
+    if (nameValueEntries.length === parsed.length) {
+      return "nameValueArray";
+    }
+
+    const pairEntries = parsed.filter((item) => Array.isArray(item) && item.length >= 2);
+    if (pairEntries.length === parsed.length) {
+      return "pairArray";
+    }
+
+    return null;
+  }
+
+  if (parsed && typeof parsed === "object") {
+    return "object";
+  }
+
+  return null;
+};
+
+const buildNormalizedMap = (parsed, format) => {
+  if (format === "object") {
+    return Object.fromEntries(
+      Object.entries(parsed).map(([key, value]) => [String(key), toDisplayString(value)])
+    );
+  }
+
+  if (format === "nameValueArray") {
+    const result = {};
+    parsed.forEach((item) => {
+      if (!item || typeof item !== "object" || Array.isArray(item)) {
+        return;
+      }
+
+      if ("name" in item) {
+        result[String(item.name)] = toDisplayString(item.value);
+      }
+    });
+    return result;
+  }
+
+  if (format === "pairArray") {
+    const result = {};
+    parsed.forEach((pair) => {
+      if (!Array.isArray(pair) || pair.length < 2) {
+        return;
+      }
+      result[String(pair[0])] = toDisplayString(pair[1]);
+    });
+    return result;
+  }
+
+  return {};
+};
+
+const parseInput = (input) => {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return {
+      normalized: {},
+      original: {},
+      format: "empty",
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    const format = detectFormat(parsed);
+    if (!format) {
+      throw new Error("Unsupported JSON structure. Use an object or an array with name/value pairs.");
+    }
+
+    return {
+      normalized: buildNormalizedMap(parsed, format),
+      original: parsed,
+      format,
+    };
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error(`Invalid JSON: ${error.message}`);
+    }
+    throw error;
+  }
+};
+
+const classifyRow = (leftValue, rightValue) => {
+  if (leftValue === undefined && rightValue === undefined) {
+    return { className: "", statusLabel: "" };
+  }
+
+  if (leftValue === undefined) {
+    return { className: "only-target", statusLabel: "Only in target" };
+  }
+
+  if (rightValue === undefined) {
+    return { className: "only-source", statusLabel: "Only in source" };
+  }
+
+  if (leftValue === rightValue) {
+    return { className: "match", statusLabel: "Match" };
+  }
+
+  return { className: "different", statusLabel: "Different" };
+};
+
+const createValueCell = (value) => {
+  const cell = document.createElement("td");
+  if (value === undefined) {
+    cell.textContent = MISSING_INDICATOR;
+    cell.classList.add("missing-value");
+  } else {
+    cell.textContent = value;
+  }
+  return cell;
+};
+
+const createActionButton = (direction, label, icon, key) => {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "action-button";
+  button.dataset.action = "copy";
+  button.dataset.direction = direction;
+  button.dataset.key = key;
+  button.title = label;
+  button.innerHTML = `<span aria-hidden="true">${icon}</span><span>${label}</span>`;
+  return button;
+};
+
+const createActionsCell = (leftValue, rightValue, key) => {
+  const cell = document.createElement("td");
+  if (leftValue === undefined && rightValue === undefined) {
+    cell.textContent = MISSING_INDICATOR;
+    cell.classList.add("missing-value");
+    return cell;
+  }
+
+  const container = document.createElement("div");
+  container.className = "results__actions";
+
+  if (rightValue !== undefined) {
+    container.appendChild(createActionButton("to-left", "Copy to source", "←", key));
+  }
+
+  if (leftValue !== undefined) {
+    container.appendChild(createActionButton("to-right", "Copy to target", "→", key));
+  }
+
+  if (!container.children.length) {
+    cell.textContent = MISSING_INDICATOR;
+    cell.classList.add("missing-value");
+    return cell;
+  }
+
+  cell.appendChild(container);
+  return cell;
+};
+
+const cloneArray = (array) => array.map((item) => {
+  if (Array.isArray(item)) {
+    return item.slice();
+  }
+  if (item && typeof item === "object") {
+    return { ...item };
+  }
+  return item;
+});
+
+const applyValueToStructure = (parseResult, key, value, preferredFormat) => {
+  const format = parseResult.format === "empty" ? preferredFormat || "object" : parseResult.format;
+  let updatedStructure;
+
+  if (format === "object") {
+    const base = parseResult.format === "empty" ? {} : { ...parseResult.original };
+    base[key] = value;
+    updatedStructure = base;
+  } else if (format === "nameValueArray") {
+    const base = Array.isArray(parseResult.original) ? cloneArray(parseResult.original) : [];
+    const index = base.findIndex(
+      (item) => item && typeof item === "object" && !Array.isArray(item) && String(item.name) === key
+    );
+
+    if (index >= 0) {
+      base[index] = { ...base[index], name: key, value };
+    } else {
+      const template = base.find((item) => item && typeof item === "object" && !Array.isArray(item));
+      if (template) {
+        const newEntry = { ...template };
+        Object.keys(newEntry).forEach((entryKey) => {
+          if (entryKey !== "name" && entryKey !== "value") {
+            newEntry[entryKey] = template[entryKey];
+          }
+        });
+        newEntry.name = key;
+        newEntry.value = value;
+        base.push(newEntry);
+      } else {
+        base.push({ name: key, value, slotSetting: false });
+      }
+    }
+
+    updatedStructure = base;
+  } else if (format === "pairArray") {
+    const base = Array.isArray(parseResult.original) ? cloneArray(parseResult.original) : [];
+    const index = base.findIndex((item) => Array.isArray(item) && String(item[0]) === key);
+    if (index >= 0) {
+      const pair = Array.isArray(base[index]) ? base[index].slice() : [];
+      pair[0] = key;
+      pair[1] = value;
+      base[index] = pair;
+    } else {
+      base.push([key, value]);
+    }
+    updatedStructure = base;
+  } else {
+    throw new Error("Unsupported target format for copy action.");
+  }
+
+  return {
+    text: JSON.stringify(updatedStructure, null, 2),
+    format,
+  };
+};
+
+const summarizeStats = (stats, total) => {
+  const parts = [];
+  if (stats.match) {
+    parts.push(`${stats.match} match${stats.match === 1 ? "" : "es"}`);
+  }
+  if (stats.different) {
+    parts.push(`${stats.different} different value${stats.different === 1 ? "" : "s"}`);
+  }
+  if (stats.onlySource) {
+    parts.push(`${stats.onlySource} only in source`);
+  }
+  if (stats.onlyTarget) {
+    parts.push(`${stats.onlyTarget} only in target`);
+  }
+
+  const suffix = parts.length ? ` (${parts.join(", ")})` : "";
+  return `Compared ${total} variable${total === 1 ? "" : "s"}.${suffix}`;
+};
+
+const compare = () => {
+  statusEl.textContent = "";
+  statusEl.classList.remove("error");
+  tbody.innerHTML = "";
+
+  let leftData;
+  let rightData;
+
+  try {
+    leftData = parseInput(leftInput.value);
+    rightData = parseInput(rightInput.value);
+  } catch (error) {
+    statusEl.textContent = error.message;
+    statusEl.classList.add("error");
+    resultTable.hidden = true;
+    return null;
+  }
+
+  const allKeys = new Set([
+    ...Object.keys(leftData.normalized),
+    ...Object.keys(rightData.normalized),
+  ]);
+
+  if (allKeys.size === 0) {
+    statusEl.textContent = "No variables detected. Paste JSON into the panels and compare again.";
+    resultTable.hidden = true;
+    return null;
+  }
+
+  const stats = {
+    match: 0,
+    different: 0,
+    onlySource: 0,
+    onlyTarget: 0,
+  };
+
+  Array.from(allKeys)
+    .sort((a, b) => a.localeCompare(b))
+    .forEach((key) => {
+      const leftValue = leftData.normalized[key];
+      const rightValue = rightData.normalized[key];
+      const { className, statusLabel } = classifyRow(leftValue, rightValue);
+
+      const row = document.createElement("tr");
+      row.className = className;
+      row.dataset.key = key;
+
+      const nameCell = document.createElement("td");
+      nameCell.textContent = key;
+      row.appendChild(nameCell);
+
+      row.appendChild(createValueCell(leftValue));
+      row.appendChild(createValueCell(rightValue));
+
+      const statusCell = document.createElement("td");
+      statusCell.textContent = statusLabel;
+      row.appendChild(statusCell);
+
+      row.appendChild(createActionsCell(leftValue, rightValue, key));
+
+      if (className === "match") {
+        stats.match += 1;
+      } else if (className === "different") {
+        stats.different += 1;
+      } else if (className === "only-source") {
+        stats.onlySource += 1;
+      } else if (className === "only-target") {
+        stats.onlyTarget += 1;
+      }
+
+      tbody.appendChild(row);
+    });
+
+  resultTable.hidden = false;
+  const summary = summarizeStats(stats, allKeys.size);
+  statusEl.textContent = summary;
+  return summary;
+};
+
+compareButton.addEventListener("click", () => {
+  compare();
+});
+
+clearButton.addEventListener("click", () => {
+  leftInput.value = "";
+  rightInput.value = "";
+  tbody.innerHTML = "";
+  resultTable.hidden = true;
+  statusEl.textContent = "Cleared inputs.";
+  statusEl.classList.remove("error");
+  leftInput.focus();
+});
+
+tbody.addEventListener("click", (event) => {
+  const target = event.target.closest("button[data-action=\"copy\"]");
+  if (!target) {
+    return;
+  }
+
+  const direction = target.dataset.direction;
+  const key = target.dataset.key;
+  if (!direction || !key) {
+    return;
+  }
+
+  const copyFromRight = direction === "to-left";
+  const sourceInput = copyFromRight ? rightInput : leftInput;
+  const targetInput = copyFromRight ? leftInput : rightInput;
+
+  try {
+    const sourceData = parseInput(sourceInput.value);
+    const targetData = parseInput(targetInput.value);
+    const sourceValue = sourceData.normalized[key];
+
+    if (sourceValue === undefined) {
+      statusEl.textContent = `Cannot copy ${key}: the value is missing on the source side.`;
+      statusEl.classList.add("error");
+      return;
+    }
+
+    const update = applyValueToStructure(
+      targetData,
+      key,
+      sourceValue,
+      sourceData.format === "empty" ? undefined : sourceData.format
+    );
+
+    targetInput.value = update.text;
+    const summary = compare();
+    if (summary) {
+      const destinationLabel = copyFromRight ? "source" : "target";
+      statusEl.textContent = `Copied ${key} to the ${destinationLabel} environment. ${summary}`;
+      statusEl.classList.remove("error");
+    }
+  } catch (error) {
+    statusEl.textContent = error.message;
+    statusEl.classList.add("error");
+  }
+});
+
+const azureSampleSource = [
+  {
+    name: "AaIntegrationRedirectUrl",
+    value: "https://vipm-clinician-dev.clarifidev.com/integrations/rethink",
+    slotSetting: false,
+  },
+  {
+    name: "AccountsApiClient:ApiBaseUrl",
+    value: "https://app-accounts-service-dev.azurewebsites.net/api/v1/",
+    slotSetting: false,
+  },
+  {
+    name: "AccountsApiClient:ApiKey",
+    value: "be717ee9-24b4-4d11-adf7-e28be4d8ef4a",
+    slotSetting: false,
+  },
+  {
+    name: "FeatureToggle:NewHomePage",
+    value: "true",
+    slotSetting: false,
+  },
+];
+
+const azureSampleTarget = [
+  {
+    name: "AaIntegrationRedirectUrl",
+    value: "https://vipm-clinician-prod.clarifidev.com/integrations/rethink",
+    slotSetting: false,
+  },
+  {
+    name: "AccountsApiClient:ApiBaseUrl",
+    value: "https://app-accounts-service.azurewebsites.net/api/v1/",
+    slotSetting: false,
+  },
+  {
+    name: "AccountsApiClient:ApiKey",
+    value: "prod-secret-key",
+    slotSetting: false,
+  },
+  {
+    name: "FeatureToggle:NewHomePage",
+    value: "false",
+    slotSetting: false,
+  },
+  {
+    name: "NewSetting",
+    value: "Enabled",
+    slotSetting: false,
+  },
+];
+
+leftInput.value = JSON.stringify(azureSampleSource, null, 2);
+rightInput.value = JSON.stringify(azureSampleTarget, null, 2);
+compare();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Environment Variables Diff Tool</title>
+  <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body>
+  <header class="page-header">
+    <h1>Environment Variables Diff Tool</h1>
+    <p>Compare Azure App Service settings or other JSON-based environment variable exports side-by-side.</p>
+  </header>
+  <main class="page-main">
+    <section class="editor-panel" aria-label="Environment variable inputs">
+      <div class="panel" aria-labelledby="source-title">
+        <header class="panel__header">
+          <h2 id="source-title">Source Environment</h2>
+        </header>
+        <textarea
+          id="left-json"
+          class="panel__editor"
+          placeholder='{"NAME":"VALUE"} or [{"name":"Setting","value":"Value"}]'
+          aria-label="Source environment JSON"
+        ></textarea>
+      </div>
+      <div class="panel" aria-labelledby="target-title">
+        <header class="panel__header">
+          <h2 id="target-title">Target Environment</h2>
+        </header>
+        <textarea
+          id="right-json"
+          class="panel__editor"
+          placeholder='{"NAME":"VALUE"} or [{"name":"Setting","value":"Value"}]'
+          aria-label="Target environment JSON"
+        ></textarea>
+      </div>
+    </section>
+    <p class="helper-text">
+      Tip: Paste raw Azure App Service setting exports (arrays with <code>name</code> and <code>value</code>) or classic key/value JSON objects on either side.
+    </p>
+    <div class="actions">
+      <button id="compare" class="btn">Compare</button>
+      <button id="clear" class="btn btn--secondary">Clear</button>
+      <span class="status" role="status" aria-live="polite" id="status"></span>
+    </div>
+    <div class="table-container" aria-live="polite">
+      <table id="result-table" class="results" hidden>
+        <thead>
+          <tr>
+            <th scope="col">Variable</th>
+            <th scope="col">Source Value</th>
+            <th scope="col">Target Value</th>
+            <th scope="col">Result</th>
+            <th scope="col" class="results__actions-header">Actions</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </main>
+  <footer class="page-footer">
+    <div class="legend">
+      <span class="legend__item legend__item--match">✔ Matched</span>
+      <span class="legend__item legend__item--only-source">⚠ Only in source</span>
+      <span class="legend__item legend__item--only-target">⚠ Only in target</span>
+      <span class="legend__item legend__item--different">✖ Different</span>
+    </div>
+  </footer>
+  <script src="assets/js/app.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extract the existing inline page styles and scripts into dedicated CSS and JS assets for maintainability
- add an actions column with copy buttons so variables can be moved left-to-right or right-to-left, including when only one side has a value
- improve result styling to highlight missing variables and keep comparison statistics in the status banner

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dbcb3401d48323b8d41b7234e2678e