### PR TITLE
Scale down layout and support inline value editing

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,416 @@
+:root {
+  color-scheme: light dark;
+  --color-background: #0f172a;
+  --color-surface: #111827;
+  --color-panel: #1f2937;
+  --color-panel-border: rgba(255, 255, 255, 0.08);
+  --color-text: #f9fafb;
+  --color-muted: #9ca3af;
+  --color-accent: #38bdf8;
+  --color-danger: #f87171;
+  --color-warning: #fbbf24;
+  --color-success: #34d399;
+  --font-base: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: "Fira Code", "Menlo", "Source Code Pro", monospace;
+  --shadow-elevated: 0 12px 32px rgba(15, 23, 42, 0.28);
+  --radius-lg: 14px;
+  --radius-md: 10px;
+  --radius-sm: 6px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--font-base);
+  background: radial-gradient(circle at top, #1f2937, #0f172a 60%);
+  color: var(--color-text);
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.12), rgba(129, 140, 248, 0.08));
+  z-index: -1;
+}
+
+.app {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  padding: 24px clamp(20px, 5vw, 56px) 32px;
+  gap: 24px;
+}
+
+.app__header {
+  text-align: center;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.app__title {
+  margin: 0 0 8px;
+  font-size: clamp(1.75rem, 2.6vw, 2.2rem);
+  letter-spacing: 0.02em;
+}
+
+.app__description {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.app__main {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.editor-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 18px;
+}
+
+.editor {
+  display: flex;
+  flex-direction: column;
+  background: rgba(17, 24, 39, 0.72);
+  border: 1px solid var(--color-panel-border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow-elevated);
+  min-height: 260px;
+}
+
+.editor__header {
+  padding: 14px 18px 10px;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.12), rgba(129, 140, 248, 0.05));
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.editor__title {
+  margin: 0;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.editor__textarea {
+  flex: 1;
+  resize: vertical;
+  min-height: 210px;
+  padding: 14px 16px;
+  border: none;
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  background: rgba(15, 23, 42, 0.85);
+  color: var(--color-text);
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  outline: none;
+}
+
+.editor__textarea::placeholder {
+  color: rgba(148, 163, 184, 0.5);
+}
+
+.editor__textarea:focus {
+  box-shadow: inset 0 0 0 2px rgba(56, 189, 248, 0.7);
+}
+
+.helper-text {
+  margin: 0;
+  color: var(--color-muted);
+  text-align: center;
+  font-size: 0.9rem;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+}
+
+.toolbar__buttons {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.btn {
+  appearance: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 8px 16px;
+  font: inherit;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease;
+}
+
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  box-shadow: none;
+}
+
+.btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 25px rgba(56, 189, 248, 0.2);
+}
+
+.btn:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.btn--secondary {
+  background: var(--color-accent);
+  color: #0f172a;
+}
+
+.btn--ghost {
+  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  color: var(--color-muted);
+}
+
+.btn--ghost:hover:not(:disabled) {
+  background: rgba(56, 189, 248, 0.12);
+  color: var(--color-text);
+}
+
+.btn--small {
+  padding: 6px 12px;
+  font-size: 0.85rem;
+}
+
+.status-panel {
+  border-radius: var(--radius-md);
+  background: rgba(17, 24, 39, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 12px 16px;
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  box-shadow: var(--shadow-elevated);
+}
+
+.status-panel__message {
+  margin: 0;
+  font-weight: 500;
+}
+
+.status-panel__message--success {
+  color: var(--color-success);
+}
+
+.status-panel__message--warning {
+  color: var(--color-warning);
+}
+
+.status-panel__message--error {
+  color: var(--color-danger);
+}
+
+.results-panel {
+  background: rgba(17, 24, 39, 0.62);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  box-shadow: var(--shadow-elevated);
+  overflow: hidden;
+}
+
+.results-table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.results-table thead {
+  background: rgba(56, 189, 248, 0.12);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+}
+
+.results-table th,
+.results-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  text-align: left;
+  vertical-align: top;
+  max-width: 300px;
+  word-break: break-word;
+  white-space: pre-wrap;
+  font-size: 0.9rem;
+}
+
+.results-table__select {
+  width: 64px;
+  max-width: 64px;
+}
+
+.results-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.results-table tbody tr {
+  transition: background 0.2s ease;
+}
+
+.results-table tbody tr:hover {
+  background: rgba(56, 189, 248, 0.07);
+}
+
+.results-table tbody tr.match {
+  background: rgba(52, 211, 153, 0.08);
+}
+
+.results-table tbody tr.different {
+  background: rgba(248, 113, 113, 0.08);
+}
+
+.results-table tbody tr.only-source {
+  background: rgba(250, 204, 21, 0.08);
+}
+
+.results-table tbody tr.only-target {
+  background: rgba(129, 140, 248, 0.1);
+}
+
+.results-table__value {
+  position: relative;
+}
+
+.results-table__value-input {
+  width: 100%;
+  max-width: 100%;
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.78);
+  color: var(--color-text);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  line-height: 1.4;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.results-table__value-input:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.7);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.2);
+}
+
+.results-table__value--missing .results-table__value-input {
+  border-style: dashed;
+  color: var(--color-muted);
+}
+
+.results-table__value-input::placeholder {
+  color: rgba(148, 163, 184, 0.6);
+}
+
+.results-table input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--color-accent);
+  cursor: pointer;
+}
+
+.bulk-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+  background: rgba(17, 24, 39, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius-md);
+  padding: 12px 16px;
+  box-shadow: var(--shadow-elevated);
+}
+
+.bulk-actions__summary {
+  font-weight: 500;
+  font-size: 0.95rem;
+}
+
+.bulk-actions__buttons {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.legend {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
+.legend__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(17, 24, 39, 0.6);
+}
+
+.legend__item--match {
+  border-color: rgba(52, 211, 153, 0.5);
+}
+
+.legend__item--different {
+  border-color: rgba(248, 113, 113, 0.5);
+}
+
+.legend__item--source {
+  border-color: rgba(250, 204, 21, 0.5);
+}
+
+.legend__item--target {
+  border-color: rgba(129, 140, 248, 0.5);
+}
+
+.app__footer {
+  margin-top: auto;
+  text-align: center;
+}
+
+@media (max-width: 768px) {
+  .app {
+    padding-inline: clamp(16px, 5vw, 28px);
+  }
+
+  .results-table th,
+  .results-table td {
+    padding: 8px 8px;
+    font-size: 0.85rem;
+  }
+
+  .results-table__select {
+    width: 56px;
+  }
+
+  .results-table__value-input {
+    font-size: 0.8rem;
+    padding: 6px 8px;
+  }
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,651 @@
+(() => {
+  const sourceInput = document.getElementById("source-input");
+  const targetInput = document.getElementById("target-input");
+  const loadSampleButton = document.getElementById("load-sample");
+  const swapButton = document.getElementById("swap");
+  const clearButton = document.getElementById("clear");
+  const statusMessage = document.getElementById("status-message");
+  const resultsTable = document.getElementById("results-table");
+  const resultsBody = resultsTable.querySelector("tbody");
+  const selectionSummary = document.getElementById("selection-summary");
+  const copyToSourceButton = document.getElementById("copy-to-source");
+  const copyToTargetButton = document.getElementById("copy-to-target");
+
+  const MISSING_INDICATOR = "—";
+  const STATUS_CLASSNAMES = {
+    success: "status-panel__message--success",
+    warning: "status-panel__message--warning",
+    error: "status-panel__message--error",
+  };
+
+  const state = {
+    selection: new Set(),
+    parses: {
+      source: createEmptyParse(),
+      target: createEmptyParse(),
+    },
+    diffRows: [],
+  };
+
+  const azureSamples = {
+    source: [
+      {
+        name: "AaIntegrationRedirectUrl",
+        value: "https://vipm-clinician-dev.clarifidev.com/integrations/rethink",
+        slotSetting: false,
+      },
+      {
+        name: "AccountsApiClient:ApiBaseUrl",
+        value: "https://app-accounts-service-dev.azurewebsites.net/api/v1/",
+        slotSetting: false,
+      },
+      {
+        name: "AccountsApiClient:ApiKey",
+        value: "be717ee9-24b4-4d11-adf7-e28be4d8ef4a",
+        slotSetting: false,
+      },
+    ],
+    target: [
+      {
+        name: "AaIntegrationRedirectUrl",
+        value: "https://vipm-clinician-prod.clarifidev.com/integrations/rethink",
+        slotSetting: false,
+      },
+      {
+        name: "AccountsApiClient:ApiBaseUrl",
+        value: "https://app-accounts-service.azurewebsites.net/api/v1/",
+        slotSetting: false,
+      },
+      {
+        name: "AccountsApiClient:ApiKey",
+        value: "prod-secret-key",
+        slotSetting: false,
+      },
+      {
+        name: "NewFeatureToggle",
+        value: "true",
+        slotSetting: false,
+      },
+    ],
+  };
+
+  function createEmptyParse() {
+    return {
+      format: "empty",
+      normalized: {},
+      original: {},
+      text: "",
+    };
+  }
+
+  function setStatus(message, tone = "warning") {
+    statusMessage.textContent = message;
+    Object.values(STATUS_CLASSNAMES).forEach((className) => {
+      statusMessage.classList.remove(className);
+    });
+    const className = STATUS_CLASSNAMES[tone];
+    if (className) {
+      statusMessage.classList.add(className);
+    }
+  }
+
+  function toDisplayString(value) {
+    if (value === null || value === undefined) {
+      return "";
+    }
+
+    if (typeof value === "string") {
+      return value;
+    }
+
+    if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+      return String(value);
+    }
+
+    if (typeof value === "object") {
+      try {
+        return JSON.stringify(value);
+      } catch (error) {
+        console.warn("Unable to stringify value", value, error);
+        return String(value);
+      }
+    }
+
+    return String(value ?? "");
+  }
+
+  function detectFormat(parsed) {
+    if (Array.isArray(parsed)) {
+      if (parsed.length === 0) {
+        return "nameValueArray";
+      }
+
+      const everyNameValue = parsed.every(
+        (entry) => entry && typeof entry === "object" && !Array.isArray(entry) && "name" in entry && "value" in entry
+      );
+      if (everyNameValue) {
+        return "nameValueArray";
+      }
+
+      const everyPair = parsed.every((entry) => Array.isArray(entry) && entry.length >= 2);
+      if (everyPair) {
+        return "pairArray";
+      }
+
+      return null;
+    }
+
+    if (parsed && typeof parsed === "object") {
+      return "object";
+    }
+
+    return null;
+  }
+
+  function buildNormalizedMap(parsed, format) {
+    if (format === "object") {
+      return Object.fromEntries(
+        Object.entries(parsed).map(([key, value]) => [String(key), toDisplayString(value)])
+      );
+    }
+
+    if (format === "nameValueArray") {
+      const result = {};
+      parsed.forEach((entry) => {
+        if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+          return;
+        }
+
+        if ("name" in entry) {
+          result[String(entry.name)] = toDisplayString(entry.value);
+        }
+      });
+      return result;
+    }
+
+    if (format === "pairArray") {
+      const result = {};
+      parsed.forEach((entry) => {
+        if (!Array.isArray(entry) || entry.length < 2) {
+          return;
+        }
+        result[String(entry[0])] = toDisplayString(entry[1]);
+      });
+      return result;
+    }
+
+    return {};
+  }
+
+  function parseEnvironment(text) {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      return createEmptyParse();
+    }
+
+    try {
+      const parsed = JSON.parse(trimmed);
+      const format = detectFormat(parsed);
+      if (!format) {
+        throw new Error(
+          "Unsupported JSON structure. Use an object or an array of objects with name/value pairs."
+        );
+      }
+
+      return {
+        format,
+        original: parsed,
+        normalized: buildNormalizedMap(parsed, format),
+        text,
+      };
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        throw new Error(`Invalid JSON: ${error.message}`);
+      }
+      throw error;
+    }
+  }
+
+  function classifyRow(leftValue, rightValue) {
+    if (leftValue === undefined && rightValue === undefined) {
+      return { className: "", label: "" };
+    }
+
+    if (leftValue === undefined) {
+      return { className: "only-target", label: "Only in target" };
+    }
+
+    if (rightValue === undefined) {
+      return { className: "only-source", label: "Only in source" };
+    }
+
+    if (leftValue === rightValue) {
+      return { className: "match", label: "Match" };
+    }
+
+    return { className: "different", label: "Different" };
+  }
+
+  function buildDiff(leftMap, rightMap) {
+    const allKeys = new Set([...Object.keys(leftMap), ...Object.keys(rightMap)]);
+    const sortedKeys = Array.from(allKeys).sort((a, b) => a.localeCompare(b));
+
+    const rows = [];
+    const stats = {
+      match: 0,
+      different: 0,
+      onlySource: 0,
+      onlyTarget: 0,
+    };
+
+    sortedKeys.forEach((key) => {
+      const leftValue = leftMap[key];
+      const rightValue = rightMap[key];
+      const { className, label } = classifyRow(leftValue, rightValue);
+
+      if (className === "match") {
+        stats.match += 1;
+      } else if (className === "different") {
+        stats.different += 1;
+      } else if (className === "only-source") {
+        stats.onlySource += 1;
+      } else if (className === "only-target") {
+        stats.onlyTarget += 1;
+      }
+
+      rows.push({
+        key,
+        leftValue,
+        rightValue,
+        className,
+        label,
+      });
+    });
+
+    return { rows, stats, total: sortedKeys.length };
+  }
+
+  function createValueCell(value, key, side) {
+    const cell = document.createElement("td");
+    cell.className = "results-table__value";
+
+    if (value === undefined) {
+      cell.classList.add("results-table__value--missing");
+    }
+
+    const input = document.createElement("input");
+    input.type = "text";
+    input.className = "results-table__value-input";
+    input.dataset.key = key;
+    input.dataset.side = side;
+    input.placeholder = value === undefined ? MISSING_INDICATOR : "";
+    input.value = value === undefined ? "" : value;
+    input.title = value === undefined ? "Not present" : value;
+    input.setAttribute(
+      "aria-label",
+      `${side === "source" ? "Source" : "Target"} value for ${key}`
+    );
+
+    cell.appendChild(input);
+    return cell;
+  }
+
+  function createSelectionCell(key) {
+    const cell = document.createElement("td");
+    cell.className = "results-table__select";
+
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.dataset.key = key;
+    checkbox.checked = state.selection.has(key);
+    checkbox.setAttribute("aria-label", `Select ${key}`);
+
+    cell.appendChild(checkbox);
+    return cell;
+  }
+
+  function renderResults(rows) {
+    resultsBody.innerHTML = "";
+    if (rows.length === 0) {
+      resultsTable.hidden = true;
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    rows.forEach((row) => {
+      const tableRow = document.createElement("tr");
+      if (row.className) {
+        tableRow.classList.add(row.className);
+      }
+      tableRow.dataset.key = row.key;
+
+      tableRow.appendChild(createSelectionCell(row.key));
+
+      const keyCell = document.createElement("td");
+      keyCell.textContent = row.key;
+      tableRow.appendChild(keyCell);
+
+      tableRow.appendChild(createValueCell(row.leftValue, row.key, "source"));
+      tableRow.appendChild(createValueCell(row.rightValue, row.key, "target"));
+
+      const statusCell = document.createElement("td");
+      statusCell.textContent = row.label;
+      tableRow.appendChild(statusCell);
+
+      fragment.appendChild(tableRow);
+    });
+
+    resultsBody.appendChild(fragment);
+    resultsTable.hidden = false;
+  }
+
+  function updateSelectionSummary() {
+    const count = state.selection.size;
+    if (count === 0) {
+      selectionSummary.textContent = "No variables selected.";
+    } else {
+      selectionSummary.textContent = `${count} variable${count === 1 ? "" : "s"} selected.`;
+    }
+
+    const disable = count === 0;
+    copyToSourceButton.disabled = disable;
+    copyToTargetButton.disabled = disable;
+  }
+
+  function pruneSelection(validKeys) {
+    const valid = new Set(validKeys);
+    Array.from(state.selection).forEach((key) => {
+      if (!valid.has(key)) {
+        state.selection.delete(key);
+      }
+    });
+  }
+
+  function summarizeStats(stats, total) {
+    if (total === 0) {
+      return "No variables detected. Paste JSON to compare.";
+    }
+
+    const parts = [];
+    if (stats.match) {
+      parts.push(`${stats.match} match${stats.match === 1 ? "" : "es"}`);
+    }
+    if (stats.different) {
+      parts.push(`${stats.different} different value${stats.different === 1 ? "" : "s"}`);
+    }
+    if (stats.onlySource) {
+      parts.push(`${stats.onlySource} only in source`);
+    }
+    if (stats.onlyTarget) {
+      parts.push(`${stats.onlyTarget} only in target`);
+    }
+
+    const suffix = parts.length ? ` (${parts.join(", ")})` : "";
+    return `Compared ${total} variable${total === 1 ? "" : "s"}.${suffix}`;
+  }
+
+  function refreshDiff(options = {}) {
+    const sourceText = sourceInput.value;
+    const targetText = targetInput.value;
+
+    try {
+      const sourceParse = parseEnvironment(sourceText);
+      const targetParse = parseEnvironment(targetText);
+
+      state.parses.source = sourceParse;
+      state.parses.target = targetParse;
+
+      const { rows, stats, total } = buildDiff(sourceParse.normalized, targetParse.normalized);
+      state.diffRows = rows;
+
+      pruneSelection(rows.map((row) => row.key));
+      renderResults(rows);
+      updateSelectionSummary();
+
+      if (total === 0) {
+        setStatus("Paste JSON to begin comparing.", "warning");
+        return;
+      }
+
+      const summary = summarizeStats(stats, total);
+      const tone = stats.different === 0 && stats.onlySource === 0 && stats.onlyTarget === 0 ? "success" : "warning";
+      setStatus(summary, tone);
+    } catch (error) {
+      state.parses.source = createEmptyParse();
+      state.parses.target = createEmptyParse();
+      state.diffRows = [];
+      state.selection.clear();
+      renderResults([]);
+      updateSelectionSummary();
+      setStatus(error.message, "error");
+    }
+  }
+
+  function cloneArray(array) {
+    return array.map((item) => {
+      if (Array.isArray(item)) {
+        return item.slice();
+      }
+      if (item && typeof item === "object") {
+        return { ...item };
+      }
+      return item;
+    });
+  }
+
+  function applyValueToStructure(parseResult, key, value, preferredFormat) {
+    const format = parseResult.format === "empty" ? preferredFormat || "object" : parseResult.format;
+    let updatedStructure;
+
+    if (format === "object") {
+      const base = parseResult.format === "empty" ? {} : { ...parseResult.original };
+      base[key] = value;
+      updatedStructure = base;
+    } else if (format === "nameValueArray") {
+      const base = Array.isArray(parseResult.original) ? cloneArray(parseResult.original) : [];
+      const index = base.findIndex(
+        (item) => item && typeof item === "object" && !Array.isArray(item) && String(item.name) === key
+      );
+
+      if (index >= 0) {
+        base[index] = { ...base[index], name: key, value };
+      } else {
+        const template = base.find((item) => item && typeof item === "object" && !Array.isArray(item));
+        if (template) {
+          const newEntry = { ...template };
+          Object.keys(newEntry).forEach((entryKey) => {
+            if (entryKey !== "name" && entryKey !== "value") {
+              newEntry[entryKey] = template[entryKey];
+            }
+          });
+          newEntry.name = key;
+          newEntry.value = value;
+          base.push(newEntry);
+        } else {
+          base.push({ name: key, value, slotSetting: false });
+        }
+      }
+
+      updatedStructure = base;
+    } else if (format === "pairArray") {
+      const base = Array.isArray(parseResult.original) ? cloneArray(parseResult.original) : [];
+      const index = base.findIndex((item) => Array.isArray(item) && String(item[0]) === key);
+      if (index >= 0) {
+        const pair = Array.isArray(base[index]) ? base[index].slice() : [];
+        pair[0] = key;
+        pair[1] = value;
+        base[index] = pair;
+      } else {
+        base.push([key, value]);
+      }
+      updatedStructure = base;
+    } else {
+      throw new Error("Unsupported target format for copy action.");
+    }
+
+    return {
+      text: JSON.stringify(updatedStructure, null, 2),
+      format,
+    };
+  }
+
+  function copySelected(direction) {
+    if (state.selection.size === 0) {
+      return;
+    }
+
+    const copyingToSource = direction === "source";
+    const fromParse = copyingToSource ? state.parses.target : state.parses.source;
+    const toParse = copyingToSource ? state.parses.source : state.parses.target;
+    const toInput = copyingToSource ? sourceInput : targetInput;
+    const destinationLabel = copyingToSource ? "source" : "target";
+    const originLabel = copyingToSource ? "target" : "source";
+
+    const keys = Array.from(state.selection);
+    const missingKeys = [];
+    let copiedCount = 0;
+    let updatedParse = toParse;
+
+    keys.forEach((key) => {
+      const value = fromParse.normalized[key];
+      if (value === undefined) {
+        missingKeys.push(key);
+        return;
+      }
+
+      const update = applyValueToStructure(updatedParse, key, value, fromParse.format === "empty" ? undefined : fromParse.format);
+      toInput.value = update.text;
+      updatedParse = parseEnvironment(update.text);
+      copiedCount += 1;
+    });
+
+    refreshDiff();
+
+    if (copiedCount === 0) {
+      setStatus(
+        `No values copied. None of the selected variables exist on the ${originLabel} side.`,
+        "warning"
+      );
+      return;
+    }
+
+    let message = `Copied ${copiedCount} variable${copiedCount === 1 ? "" : "s"} to the ${destinationLabel} environment.`;
+    if (missingKeys.length) {
+      message += ` Skipped ${missingKeys.length} missing on the ${originLabel} side (${missingKeys.join(", ")}).`;
+    }
+    setStatus(message, "success");
+  }
+
+  function handleSelectionChange(event) {
+    const checkbox = event.target;
+    if (!checkbox.matches('input[type="checkbox"][data-key]')) {
+      return;
+    }
+
+    const key = checkbox.dataset.key;
+    if (!key) {
+      return;
+    }
+
+    if (checkbox.checked) {
+      state.selection.add(key);
+    } else {
+      state.selection.delete(key);
+    }
+
+    updateSelectionSummary();
+  }
+
+  function handleValueInput(event) {
+    const input = event.target;
+    if (!input.classList.contains("results-table__value-input")) {
+      return;
+    }
+
+    const { key, side } = input.dataset;
+    if (!key || (side !== "source" && side !== "target")) {
+      return;
+    }
+
+    const parse = state.parses[side];
+    const otherParse = state.parses[side === "source" ? "target" : "source"];
+    const preferredFormat =
+      parse.format !== "empty"
+        ? parse.format
+        : otherParse.format !== "empty"
+        ? otherParse.format
+        : undefined;
+
+    const selectionStart = input.selectionStart ?? input.value.length;
+    const selectionEnd = input.selectionEnd ?? input.value.length;
+
+    try {
+      const update = applyValueToStructure(parse, key, input.value, preferredFormat);
+      const destinationInput = side === "source" ? sourceInput : targetInput;
+      destinationInput.value = update.text;
+      refreshDiff();
+
+      const restoreFocus = () => {
+        const escapedKey =
+          typeof CSS !== "undefined" && typeof CSS.escape === "function"
+            ? CSS.escape(key)
+            : key.replace(/[^a-zA-Z0-9_-]/g, "\\$&");
+        const selector = `.results-table__value-input[data-key="${escapedKey}"][data-side="${side}"]`;
+        const nextInput = resultsBody.querySelector(selector);
+        if (nextInput) {
+          nextInput.focus();
+          try {
+            nextInput.setSelectionRange(selectionStart, selectionEnd);
+          } catch (error) {
+            // Some input types may not support selection ranges; safely ignore.
+          }
+        }
+      };
+
+      if (typeof queueMicrotask === "function") {
+        queueMicrotask(restoreFocus);
+      } else {
+        setTimeout(restoreFocus, 0);
+      }
+    } catch (error) {
+      setStatus(error.message, "error");
+    }
+  }
+
+  function loadSamples() {
+    sourceInput.value = JSON.stringify(azureSamples.source, null, 2);
+    targetInput.value = JSON.stringify(azureSamples.target, null, 2);
+    refreshDiff();
+  }
+
+  function swapInputs() {
+    const sourceText = sourceInput.value;
+    sourceInput.value = targetInput.value;
+    targetInput.value = sourceText;
+    refreshDiff();
+  }
+
+  function clearInputs() {
+    sourceInput.value = "";
+    targetInput.value = "";
+    state.selection.clear();
+    refreshDiff();
+    setStatus("Cleared inputs.", "warning");
+  }
+
+  function initialize() {
+    sourceInput.addEventListener("input", () => refreshDiff());
+    targetInput.addEventListener("input", () => refreshDiff());
+    resultsBody.addEventListener("change", handleSelectionChange);
+    resultsBody.addEventListener("input", handleValueInput);
+    copyToSourceButton.addEventListener("click", () => copySelected("source"));
+    copyToTargetButton.addEventListener("click", () => copySelected("target"));
+    loadSampleButton.addEventListener("click", loadSamples);
+    swapButton.addEventListener("click", swapInputs);
+    clearButton.addEventListener("click", clearInputs);
+
+    loadSamples();
+  }
+
+  initialize();
+})();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Environment Variables Diff Tool</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <div class="app">
+      <header class="app__header">
+        <h1 class="app__title">Environment Variables Diff Tool</h1>
+        <p class="app__description">
+          Paste JSON exports from Azure App Service (name/value arrays) or any platform that delivers
+          environment variables as JSON objects to compare their keys and values side by side.
+        </p>
+      </header>
+
+      <main class="app__main">
+        <section class="editor-grid" aria-label="Environment variable inputs">
+          <article class="editor" aria-labelledby="source-title">
+            <header class="editor__header">
+              <h2 id="source-title" class="editor__title">Source environment</h2>
+            </header>
+            <textarea
+              id="source-input"
+              class="editor__textarea"
+              spellcheck="false"
+              placeholder='{"NAME":"VALUE"}\n[{"name":"Setting","value":"Value"}]'
+              aria-label="Source environment JSON"
+            ></textarea>
+          </article>
+
+          <article class="editor" aria-labelledby="target-title">
+            <header class="editor__header">
+              <h2 id="target-title" class="editor__title">Target environment</h2>
+            </header>
+            <textarea
+              id="target-input"
+              class="editor__textarea"
+              spellcheck="false"
+              placeholder='{"NAME":"VALUE"}\n[{"name":"Setting","value":"Value"}]'
+              aria-label="Target environment JSON"
+            ></textarea>
+          </article>
+        </section>
+
+        <p class="helper-text">
+          Supported formats include objects (<code>{"NAME":"VALUE"}</code>), arrays of name/value objects, and
+          arrays of key/value tuples. Copying preserves the detected format.
+        </p>
+
+        <div class="toolbar" aria-label="Comparison controls">
+          <div class="toolbar__buttons">
+            <button type="button" id="load-sample" class="btn btn--ghost">Load Azure sample</button>
+            <button type="button" id="swap" class="btn btn--ghost">Swap sides</button>
+          </div>
+          <div class="toolbar__buttons">
+            <button type="button" id="clear" class="btn btn--secondary">Clear</button>
+          </div>
+        </div>
+
+        <section class="status-panel" aria-live="polite">
+          <p id="status-message" class="status-panel__message">Paste JSON to begin comparing.</p>
+        </section>
+
+        <section class="results-panel" aria-label="Comparison results">
+          <table id="results-table" class="results-table" hidden>
+            <thead>
+              <tr>
+                <th scope="col" class="results-table__select">Select</th>
+                <th scope="col">Variable</th>
+                <th scope="col">Source value</th>
+                <th scope="col">Target value</th>
+                <th scope="col">Status</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </section>
+
+        <section class="bulk-actions" aria-live="polite">
+          <div class="bulk-actions__summary" id="selection-summary">No variables selected.</div>
+          <div class="bulk-actions__buttons">
+            <button type="button" id="copy-to-source" class="btn btn--secondary btn--small" disabled>
+              Copy to source
+            </button>
+            <button type="button" id="copy-to-target" class="btn btn--secondary btn--small" disabled>
+              Copy to target
+            </button>
+          </div>
+        </section>
+      </main>
+
+      <footer class="app__footer">
+        <div class="legend" aria-label="Legend">
+          <span class="legend__item legend__item--match">✔ Match</span>
+          <span class="legend__item legend__item--different">✖ Different</span>
+          <span class="legend__item legend__item--source">⚠ Only in source</span>
+          <span class="legend__item legend__item--target">⚠ Only in target</span>
+        </div>
+      </footer>
+    </div>
+
+    <script src="assets/js/app.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- tighten spacing, typography, and component sizing so the comparison UI feels more compact
- render each environment value as an inline input with updated styling and missing-state cues
- sync inline edits back to the parsed JSON structures so comparisons refresh as the user types

## Testing
- not run (UI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68dbcb3401d48323b8d41b7234e2678e